### PR TITLE
chore: update environment configuration properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ target/
 *.iml
 *.ipr
 *.class
-
-target
 *.log
 
 ### NetBeans ###
@@ -32,6 +30,11 @@ target
 build/
 !**/src/main/**/build/
 !**/src/test/**/build/
+
+### Environment files ###
+.env
+.env.local
+.env.production
 
 ### VS Code ###
 .vscode/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,23 +1,26 @@
+# Application
 spring.application.name=backend-order-service
-server.port=8082
+server.port=${SERVER_PORT:8082}
+server.servlet.context-path=/
+
+# Database
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://localhost:5432/orderdb
-spring.datasource.username=postgres
-spring.datasource.password=1234567890
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/orderdb}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:1234567890}
+
+# JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Kolkata
+spring.jpa.properties.hibernate.jdbc.time_zone=${TZ:Asia/Kolkata}
 
+# Error handling
 server.error.include-stacktrace=never
 server.error.include-exception=false
 
-server.servlet.context-path=/
-
+# Liquibase
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 
-#Security config
-#spring.security.user.name=pra
-#spring.security.user.password=pass
-
-jwt.secretKey=ahgvdahfuegfrgr8348098u409fvijknknjdjvkjkjfdnkawejhgcjgcutcrd6798y9t675675etfgc566yf
+# JWT
+jwt.secretKey=${JWT_SECRET_KEY:ahgvdahfuegfrgr8348098u409fvijknknjdjvkjkjfdnkawejhgcjgcutcrd6798y9t675675etfgc566yf}


### PR DESCRIPTION
Moved sensitive configuration (database credentials, secret keys) from hardcoded values in `.properties` files to environment variables to avoid exposing secrets in the repository.

Added default fallback values so that the application can still run locally for development or testing without requiring a `.env` file. This allows new contributors to clone the repository and run the project immediately while still supporting secure configuration through environment variables in production environments.
